### PR TITLE
Update and fsc.hdf5-io requirement, drop python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 cache: pip
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/nodefinder/__init__.py
+++ b/nodefinder/__init__.py
@@ -5,7 +5,7 @@
 """A tool to find and identify nodal features in band structures.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 from . import coordinate_system
 from . import search

--- a/nodefinder/search/result/_search_result_container.py
+++ b/nodefinder/search/result/_search_result_container.py
@@ -36,8 +36,10 @@ class SearchResultContainer(SimpleHDF5Mapping):
     """
 
     HDF5_ATTRIBUTES = [
-        'coordinate_system', 'minimization_results', 'dist_cutoff',
-        'gap_threshold', 'refined_results'
+        'coordinate_system',
+        'minimization_results',
+        'dist_cutoff',
+        'gap_threshold',
     ]
     HDF5_OPTIONAL = ['refined_results']
 

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ import re
 import sys
 from setuptools import setup, find_packages
 
-if sys.version_info < (3, 5):
-    raise 'Must use Python version 3.5 or higher.'
+if sys.version_info < (3, 6):
+    raise 'Must use Python version 3.6 or higher.'
 
 with open('./README.md', 'r') as f:
     README = f.read()
@@ -40,9 +40,9 @@ setup(
     'A tool for studying the nodal features of potential lanscapes.',
     install_requires=[
         'numpy', 'scipy', 'matplotlib', 'decorator', 'fsc.export',
-        'fsc.hdf5-io>=0.6.0', 'fsc.async_tools', 'networkx>=2.0'
+        'fsc.hdf5-io~=1.0', 'fsc.async_tools', 'networkx>=2.0'
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     extras_require=EXTRAS_REQUIRE,
     long_description=README,
     long_description_content_type="text/markdown",
@@ -50,7 +50,6 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Natural Language :: English', 'Operating System :: Unix',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
According to the fsc.hdf5-io change, fix the HDF5_OPTIONAL use.